### PR TITLE
Change base image to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-FROM ubuntu
+FROM dmonakhov/alpine-fio
 
 MAINTAINER Lee Liu <lee@logdna.com>
-
-RUN apt-get update && apt-get install -y \
-    fio
 
 VOLUME /tmp
 WORKDIR /tmp

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 set -e
 
 if [ "$DBENCH_MOUNTPOINT" == "" ]; then


### PR DESCRIPTION
From 170MB to 10MB image size makes the job creation a little bit faster.
Beware that I had to change from `bash` to `sh` to be able to make it work on alpine.