### PR TITLE
Change some code and automation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM dmonakhov/alpine-fio
 
-MAINTAINER Lee Liu <lee@logdna.com>
+MAINTAINER Lee Liu <lee@logdna.com>, Hoon Jo <pagaia@hotmail.com>
+
+# add due to grep -P doesn't support on alpine
+apk add --no-cache --upgrade grep
 
 VOLUME /tmp
 WORKDIR /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,31 @@
-FROM dmonakhov/alpine-fio
+FROM alpine
 
-MAINTAINER Lee Liu <lee@logdna.com>, Hoon Jo <pagaia@hotmail.com>
+MAINTAINER Dmitry Monakhov dmonakhov@openvz.org
 
-# add due to grep -P doesn't support on alpine
-apk add --no-cache --upgrade grep
+# Install build deps + permanent dep: libaio
+RUN apk --no-cache add \
+    	make \
+    	alpine-sdk \
+    	zlib-dev \
+    	libaio-dev \
+    	linux-headers \
+	    coreutils \
+      grep \
+    	libaio && \
+    git clone https://github.com/axboe/fio && \
+    cd fio && \
+    ./configure && \
+    make -j`nproc` && \
+    make install && \
+    cd .. && \
+    rm -rf fio && \
+    apk --no-cache del \
+    	make \
+    	alpine-sdk \
+    	zlib-dev \
+    	libaio-dev \
+    	linux-headers \
+    	coreutils
 
 VOLUME /tmp
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Mixed Random Read/Write IOPS: 43.1k/14.4k
 * It's useful to test multiple disk sizes as most cloud providers price IOPS per GB provisioned. So a `4000Gi` volume will perform better than a `1000Gi` volume. Just edit the yaml, `kubectl delete -f dbench.yaml` and run `kubectl apply -f dbench.yaml` again after deprovision/delete completes.
 * A list of all `fio` tests are in [docker-entrypoint.sh](https://github.com/logdna/dbench/blob/master/docker-entrypoint.sh).
 
+
+## Fixed history (Mar 28 2022)
+Dbench Summary could not show up properly when parameter have blank(s) - add to \b on docker-entrypoint
+
+
 ## Contributors
 
 * Lee Liu (LogDNA)

--- a/dbench.yaml
+++ b/dbench.yaml
@@ -1,48 +1,55 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: dbench-pv-claim
+  name: kdbench-pv-claim
+  labels:
+    fio: kdbench
 spec:
-  storageClassName: ssd
-  # storageClassName: gp2
-  # storageClassName: local-storage
-  # storageClassName: ibmc-block-bronze
-  # storageClassName: ibmc-block-silver
-  # storageClassName: ibmc-block-gold
+  storageClassName: your-storageclass
+  # storageClassName: managed-nfs-storage 
+  # storageClassName: gp2 
+  # storageClassName: default 
+  # storageClassName: standard 
+  # storageClassName: nks-block-storage
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1000Gi
+      storage: 100Gi
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: dbench
+  name: kdbench
+  labels:
+    fio: kdbench
 spec:
+  ttlSecondsAfterFinished: 0
   template:
     spec:
       containers:
-      - name: dbench
-        image: logdna/dbench:latest
+      - name: kdbench
+        image: sysnet4admin/kdbench:latest
         imagePullPolicy: Always
         env:
-          - name: DBENCH_MOUNTPOINT
-            value: /data
-          # - name: DBENCH_QUICK
+          - name: KDBENCH_MOUNTPOINT
+            value: /ON-your-storageclass
+          - name: STORAGECLASS
+            value: your-storageclass
+          # - name: KDBENCH_QUICK
           #   value: "yes"
           # - name: FIO_SIZE
           #   value: 1G
           # - name: FIO_OFFSET_INCREMENT
           #   value: 256M
           # - name: FIO_DIRECT
-          #   value: "0"
+          #   value: "1"
         volumeMounts:
-        - name: dbench-pv
-          mountPath: /data
+        - name: kdbench-pv
+          mountPath: /ON-your-storageclass
       restartPolicy: Never
       volumes:
-      - name: dbench-pv
+      - name: kdbench-pv
         persistentVolumeClaim:
-          claimName: dbench-pv-claim
+          claimName: kdbench-pv-claim
   backoffLimit: 4

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -95,9 +95,9 @@ if [ "$1" = 'fio' ]; then
     echo ==================
     echo "Random Read/Write IOPS: $READ_IOPS_VAL/$WRITE_IOPS_VAL. BW: $READ_BW_VAL / $WRITE_BW_VAL"
     if [ -z $DBENCH_QUICK ] || [ "$DBENCH_QUICK" == "no" ]; then
-        echo "Average Latency (usec) Read/Write: $READ_LATENCY_VAL/$WRITE_LATENCY_VAL"
+        echo "Average Latency (usec) Read/Write: $READ_LATENCY_VAL / $WRITE_LATENCY_VAL"
         echo "Sequential Read/Write: $READ_SEQ_VAL / $WRITE_SEQ_VAL"
-        echo "Mixed Random Read/Write IOPS: $RW_MIX_R_IOPS/$RW_MIX_W_IOPS"
+        echo "Mixed Random Read/Write IOPS: $RW_MIX_R_IOPS / $RW_MIX_W_IOPS"
     fi
 
     rm $DBENCH_MOUNTPOINT/fiotest

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -55,7 +55,7 @@ if [ "$1" = 'fio' ]; then
         READ_LATENCY=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --name=read_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s)
         echo "$READ_LATENCY"
         READ_LATENCY_VAL=$(echo "$READ_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[\b 0-9.]+'|cut -d'=' -f2)
-        READ_LATENCY_KEY=$(echo "$READ_LATENCY"|grep ' lat.*avg'|grep -oP '(?<=lat )[^ ]*' |grep -Eoi '[a-z]+'
+        READ_LATENCY_KEY=$(echo "$READ_LATENCY"|grep ' lat.*avg'|grep -oP '(?<=lat )[^ ]*' |grep -Eoi '[a-z]+')
         echo
         echo
 
@@ -63,7 +63,7 @@ if [ "$1" = 'fio' ]; then
         WRITE_LATENCY=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --name=write_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s)
         echo "$WRITE_LATENCY"
         WRITE_LATENCY_VAL=$(echo "$WRITE_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[\b 0-9.]+'|cut -d'=' -f2)
-        WRITE_LATENCY_KEY=$(echo "$WRITE_LATENCY"|grep ' lat.*avg'|grep -oP '(?<=lat )[^ ]*' |grep -Eoi '[a-z]+'
+        WRITE_LATENCY_KEY=$(echo "$WRITE_LATENCY"|grep ' lat.*avg'|grep -oP '(?<=lat )[^ ]*' |grep -Eoi '[a-z]+')
         echo
         echo
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -54,14 +54,14 @@ if [ "$1" = 'fio' ]; then
         echo Testing Read Latency...
         READ_LATENCY=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --name=read_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s)
         echo "$READ_LATENCY"
-        READ_LATENCY_VAL=$(echo "$READ_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[0-9.]+'|cut -d'=' -f2)
+        READ_LATENCY_VAL=$(echo "$READ_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[\b 0-9.]+'|cut -d'=' -f2)
         echo
         echo
 
         echo Testing Write Latency...
         WRITE_LATENCY=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --name=write_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s)
         echo "$WRITE_LATENCY"
-        WRITE_LATENCY_VAL=$(echo "$WRITE_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[0-9.]+'|cut -d'=' -f2)
+        WRITE_LATENCY_VAL=$(echo "$WRITE_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[\b 0-9.]+'|cut -d'=' -f2)
         echo
         echo
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -92,14 +92,17 @@ if [ "$1" = 'fio' ]; then
 
     echo All tests complete.
     echo
-    echo ==================
-    echo = Dbench Summary =
-    echo ==================
-    echo "Random Read/Write IOPS: $READ_IOPS_VAL/$WRITE_IOPS_VAL. BW: $READ_BW_VAL / $WRITE_BW_VAL"
+    echo =============================
+    echo = Kubernetes Dbench Summary =
+    echo =============================
+    echo -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+    echo -e "|| Random Read/Write IOPS\t | $READ_IOPS_VAL / $WRITE_IOPS_VAL\t ||" 
+    echo -e "|| Bandwidth Read/Write\t | $READ_BW_VAL / $WRITE_BW_VAL\t ||"
     if [ -z $DBENCH_QUICK ] || [ "$DBENCH_QUICK" == "no" ]; then
-      echo "Average Latency Read/Write: $READ_LATENCY_VAL($READ_LATENCY_UNIT) / $WRITE_LATENCY_VAL($WRITE_LATENCY_UNIT)"
-      echo "Sequential Read/Write: $READ_SEQ_VAL / $WRITE_SEQ_VAL"
-      echo "Mixed Random Read/Write IOPS: $RW_MIX_R_IOPS / $RW_MIX_W_IOPS"
+      echo -e "|| Average Latency Read/Write\t | $READ_LATENCY_VAL($READ_LATENCY_UNIT) / $WRITE_LATENCY_VAL($WRITE_LATENCY_UNIT)\t ||"
+      echo -e "|| Sequential Read/Write\t | $READ_SEQ_VAL / $WRITE_SEQ_VAL\t ||"
+      echo -e "|| Mixed Random Read/Write IOPS\t | $RW_MIX_R_IOPS / $RW_MIX_W_IOPS\t ||"
+    echo -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
     fi
 
     rm $DBENCH_MOUNTPOINT/fiotest

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -55,7 +55,7 @@ if [ "$1" = 'fio' ]; then
         READ_LATENCY=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --name=read_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s)
         echo "$READ_LATENCY"
         READ_LATENCY_VAL=$(echo "$READ_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[\b 0-9.]+'|cut -d'=' -f2)
-        READ_LATENCY_KEY=$(echo "$READ_LATENCY"|grep ' lat.*avg'|grep -oP '(?<=lat )[^ ]*' |grep -Eoi '[a-z]+')
+        READ_LATENCY_UNIT=$(echo "$READ_LATENCY"|grep ' lat.*avg'|grep -oP '(?<=lat )[^ ]*'|grep -Eoi '[a-z]+')
         echo
         echo
 
@@ -63,7 +63,7 @@ if [ "$1" = 'fio' ]; then
         WRITE_LATENCY=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --name=write_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s)
         echo "$WRITE_LATENCY"
         WRITE_LATENCY_VAL=$(echo "$WRITE_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[\b 0-9.]+'|cut -d'=' -f2)
-        WRITE_LATENCY_KEY=$(echo "$WRITE_LATENCY"|grep ' lat.*avg'|grep -oP '(?<=lat )[^ ]*' |grep -Eoi '[a-z]+')
+        WRITE_LATENCY_UNIT=$(echo "$WRITE_LATENCY"|grep ' lat.*avg'|grep -oP '(?<=lat )[^ ]*'|grep -Eoi '[a-z]+')
         echo
         echo
 
@@ -97,7 +97,7 @@ if [ "$1" = 'fio' ]; then
     echo ==================
     echo "Random Read/Write IOPS: $READ_IOPS_VAL/$WRITE_IOPS_VAL. BW: $READ_BW_VAL / $WRITE_BW_VAL"
     if [ -z $DBENCH_QUICK ] || [ "$DBENCH_QUICK" == "no" ]; then
-      echo "Average Latency Read/Write: ($READ_LATENCY_KEY)$READ_LATENCY_VAL / ($WRITE_LATENCY_KEY)$WRITE_LATENCY_VAL"
+      echo "Average Latency Read/Write: $READ_LATENCY_VAL($READ_LATENCY_UNIT) / $WRITE_LATENCY_VAL($WRITE_LATENCY_UNIT")
       echo "Sequential Read/Write: $READ_SEQ_VAL / $WRITE_SEQ_VAL"
       echo "Mixed Random Read/Write IOPS: $RW_MIX_R_IOPS / $RW_MIX_W_IOPS"
     fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -55,6 +55,7 @@ if [ "$1" = 'fio' ]; then
         READ_LATENCY=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --name=read_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s)
         echo "$READ_LATENCY"
         READ_LATENCY_VAL=$(echo "$READ_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[\b 0-9.]+'|cut -d'=' -f2)
+        READ_LATENCY_KEY=$(echo "$READ_LATENCY"|grep ' lat.*avg'|grep -oP '(?<=lat )[^ ]*' |grep -Eoi '[a-z]+'
         echo
         echo
 
@@ -62,6 +63,7 @@ if [ "$1" = 'fio' ]; then
         WRITE_LATENCY=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --name=write_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s)
         echo "$WRITE_LATENCY"
         WRITE_LATENCY_VAL=$(echo "$WRITE_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[\b 0-9.]+'|cut -d'=' -f2)
+        WRITE_LATENCY_KEY=$(echo "$WRITE_LATENCY"|grep ' lat.*avg'|grep -oP '(?<=lat )[^ ]*' |grep -Eoi '[a-z]+'
         echo
         echo
 
@@ -95,9 +97,9 @@ if [ "$1" = 'fio' ]; then
     echo ==================
     echo "Random Read/Write IOPS: $READ_IOPS_VAL/$WRITE_IOPS_VAL. BW: $READ_BW_VAL / $WRITE_BW_VAL"
     if [ -z $DBENCH_QUICK ] || [ "$DBENCH_QUICK" == "no" ]; then
-        echo "Average Latency (usec) Read/Write: $READ_LATENCY_VAL / $WRITE_LATENCY_VAL"
-        echo "Sequential Read/Write: $READ_SEQ_VAL / $WRITE_SEQ_VAL"
-        echo "Mixed Random Read/Write IOPS: $RW_MIX_R_IOPS / $RW_MIX_W_IOPS"
+      echo "Average Latency Read/Write: ($READ_LATENCY_KEY)$READ_LATENCY_VAL / ($WRITE_LATENCY_KEY)$WRITE_LATENCY_VAL"
+      echo "Sequential Read/Write: $READ_SEQ_VAL / $WRITE_SEQ_VAL"
+      echo "Mixed Random Read/Write IOPS: $RW_MIX_R_IOPS / $RW_MIX_W_IOPS"
     fi
 
     rm $DBENCH_MOUNTPOINT/fiotest

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -97,7 +97,7 @@ if [ "$1" = 'fio' ]; then
     echo ==================
     echo "Random Read/Write IOPS: $READ_IOPS_VAL/$WRITE_IOPS_VAL. BW: $READ_BW_VAL / $WRITE_BW_VAL"
     if [ -z $DBENCH_QUICK ] || [ "$DBENCH_QUICK" == "no" ]; then
-      echo "Average Latency Read/Write: $READ_LATENCY_VAL($READ_LATENCY_UNIT) / $WRITE_LATENCY_VAL($WRITE_LATENCY_UNIT")
+      echo "Average Latency Read/Write: $READ_LATENCY_VAL($READ_LATENCY_UNIT) / $WRITE_LATENCY_VAL($WRITE_LATENCY_UNIT)"
       echo "Sequential Read/Write: $READ_SEQ_VAL / $WRITE_SEQ_VAL"
       echo "Mixed Random Read/Write IOPS: $RW_MIX_R_IOPS / $RW_MIX_W_IOPS"
     fi


### PR DESCRIPTION
Hi leeliu, 

I hope you have been well. 
I would like to merge the code to some bug, update fio image and other automation purpose. 
However it looks like orphan repo. 

Anyhow I would like to improve your base code. 
And feel free to let me know when you are available. 

I am willing to merge and contribute your code. 
Here is modified code all. 
I apologize in advance if you feel uncomfortable.  

https://github.com/sysnet4admin/kDbench

# DEMO
`Click to run`
 
[![image](https://user-images.githubusercontent.com/29163931/162861279-57a88016-9321-42c9-899d-b526ca37fa67.png)](https://github.com/sysnet4admin/kDbench/raw/main/img/kdbench-demo.gif)


# Interactive mode 

```bash 
$ kdbench 
# select one of them 
efs-sc 
gp2

# run automatically 
persistentvolumeclaim/kdbench-pv-claim created
job.batch/kdbench created
Waiting for kdbench's load....Working dir: /ON-efs-sc

Testing Read IOPS...
read_iops: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=64
fio-3.29-148-ge3de2
Starting 1 process
read_iops: Laying out IO file (1 file / 2048MiB)
<snipped>
All tests complete for [efs-sc]

=============================
= Kubernetes Dbench Summary =
=============================
Random Read/Write IOPS............................ [24.4k / 7330]
Bandwidth Read/Write.............................. [300MiB/s / 100MiB/s]
Average Latency Read(usec)/Write(usec)............ [2542.07 / 7907.11]
Sequential Read/Write............................. [301MiB/s / 102MiB/s]
Mixed Random Read/Write IOPS...................... [7121 / 2391]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
Waiting for job finished by ttlSecondsAfterFinished...

# delete automatically
kdbench finsihed and pvc will delete
persistentvolumeclaim "kdbench-pv-claim" deleted
```

